### PR TITLE
Highlight all Fields in data-required group

### DIFF
--- a/src/jquery.progressforms.js
+++ b/src/jquery.progressforms.js
@@ -256,7 +256,7 @@
 					}
 
 					if (!checked && checkboxes.length > 0) {
-						notFilled = $(checkboxes[0]);
+						notFilled = $(checkboxes);
 					}
 				}
 			}


### PR DESCRIPTION
When working with this plugin I noticed that when no items in a data-required group were filled in only the first item was given the validate-failed class and highlighted red.  This change will highlight all the items in the data-required group instead.
